### PR TITLE
fix glob pattern

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -8,7 +8,7 @@ module.exports = {
   arrowParens: 'always',
   overrides: [
     {
-      files: '{*.y?(a)ml,.*.js?(on),.*.y?(a)ml,*.md,.prettierrc,.stylelintrc,.babelrc}',
+      files: ['.prettierrc,.stylelintrc,.babelrc', '*.{y{a,}ml,js{on,},md}'],
       options: {
         tabWidth: 2,
       },


### PR DESCRIPTION
`*.js?(on)`과 같은 표기법은 extended glob입니다. 셸 설정에 따라 지원하지 않는 경우가 있습니다. (저 안됨..) 그래서 표준 glob만을 사용하게끔 변경했습니다.

근데 .js, .json, .md 스페이스 두칸 설정은 루트 디렉토리에만 적용하는 거 맞죠?