### PR TITLE
remove tabWidth:2 override

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -8,12 +8,6 @@ module.exports = {
   arrowParens: 'always',
   overrides: [
     {
-      files: ['.prettierrc,.stylelintrc,.babelrc', '*.{y{a,}ml,js{on,},md}'],
-      options: {
-        tabWidth: 2,
-      },
-    },
-    {
       files: '{**/.vscode/*.json,**/tsconfig.json,**/tsconfig.*.json}',
       options: {
         parser: 'json5',


### PR DESCRIPTION
depth가 깊은 파일들이 아니라서 `tabWidth: 2`로 지정할 이유가 없습니다.
back-end, front-end config의 tabWidth 설정을 따르도록 합시다.


